### PR TITLE
improve suspense behavior for async read atom

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,9 +24,9 @@
     "gzipped": 1922
   },
   "index.js": {
-    "bundled": 10583,
-    "minified": 4557,
-    "gzipped": 1669,
+    "bundled": 10692,
+    "minified": 4614,
+    "gzipped": 1684,
     "treeshaked": {
       "rollup": {
         "code": 300,
@@ -38,13 +38,13 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 11643,
-    "minified": 5161,
-    "gzipped": 1747
+    "bundled": 11758,
+    "minified": 5226,
+    "gzipped": 1762
   },
   "index.iife.js": {
-    "bundled": 12312,
-    "minified": 4294,
-    "gzipped": 1566
+    "bundled": 12437,
+    "minified": 4359,
+    "gzipped": 1580
   }
 }

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -24,7 +24,7 @@ const warningObject = new Proxy(
 )
 
 export type Actions = {
-  init: (id: symbol, atom: AnyAtom) => void
+  init: (id: symbol | null, atom: AnyAtom) => void
   dispose: (id: symbol) => void
   write: (atom: AnyWritableAtom, update: unknown) => void
 }
@@ -89,7 +89,7 @@ const getAtomStateValue = (state: State, atom: AnyAtom) => {
 }
 
 const initAtom = (
-  id: symbol,
+  id: symbol | null,
   initializingAtom: AnyAtom,
   setState: Dispatch<SetStateAction<State>>,
   dependentsMap: DependentsMap
@@ -97,9 +97,11 @@ const initAtom = (
   const createAtomState = (
     prevState: State,
     atom: AnyAtom,
-    dependent: AnyAtom | symbol
+    dependent: AnyAtom | symbol | null
   ) => {
-    addDependent(dependentsMap, atom, dependent)
+    if (dependent) {
+      addDependent(dependentsMap, atom, dependent)
+    }
     const partialState: State = new Map()
     let atomState = prevState.get(atom)
     if (atomState) {
@@ -320,7 +322,7 @@ export const Provider: React.FC = ({ children }) => {
   }
   const actions = useMemo(
     () => ({
-      init: (id: symbol, atom: AnyAtom) =>
+      init: (id: symbol | null, atom: AnyAtom) =>
         initAtom(id, atom, setState, dependentsMapRef.current as DependentsMap),
       dispose: (id: symbol) =>
         disposeAtom(id, setState, dependentsMapRef.current as DependentsMap),

--- a/src/atom.ts
+++ b/src/atom.ts
@@ -24,7 +24,7 @@ export function atom<Value, Update>(
 export function atom<Value, Update>(
   read: (get: Getter) => Promise<Value>,
   write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
-): WritableAtom<Value | null, Update>
+): WritableAtom<Value | Promise<Value>, Update>
 
 // read-only derived atom
 export function atom<Value>(
@@ -34,7 +34,7 @@ export function atom<Value>(
 // async-read read-only derived atom
 export function atom<Value>(
   read: (get: Getter) => Promise<Value>
-): Atom<Value | null>
+): Atom<Value | Promise<Value>>
 
 // primitive atom
 export function atom<Value>(
@@ -45,9 +45,7 @@ export function atom<Value, Update>(
   read: Value | ((get: Getter) => Value | Promise<Value>),
   write?: (get: Getter, set: Setter, update: Update) => void | Promise<void>
 ) {
-  const instance = ({
-    initialValue: null,
-  } as unknown) as WritableAtom<Value, Update>
+  const instance = {} as WritableAtom<Value | Promise<Value>, Update>
   if (typeof read === 'function') {
     instance.read = read as (get: Getter) => Value | Promise<Value>
     const value = (read as (get: Getter) => Value | Promise<Value>)(
@@ -57,9 +55,8 @@ export function atom<Value, Update>(
       value.then((v) => {
         instance.initialValue = v
       })
-    } else {
-      instance.initialValue = value
     }
+    instance.initialValue = value
   } else {
     instance.initialValue = read
     instance.read = (get: Getter) => get(instance)

--- a/src/useAtom.ts
+++ b/src/useAtom.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import { useContext, useContextSelector } from 'use-context-selector'
 
 import { StateContext, ActionsContext, AtomState } from './Provider'
-import { Atom, WritableAtom, AnyWritableAtom } from './types'
+import { Atom, WritableAtom, AnyWritableAtom, NonPromise } from './types'
 import { useIsoLayoutEffect } from './utils'
 
 const isWritable = <Value, Update>(
@@ -12,9 +12,9 @@ const isWritable = <Value, Update>(
 
 export function useAtom<Value, Update>(
   atom: WritableAtom<Value, Update>
-): [Value, (update: Update) => void]
+): [NonPromise<Value>, (update: Update) => void]
 
-export function useAtom<Value>(atom: Atom<Value>): [Value, never]
+export function useAtom<Value>(atom: Atom<Value>): [NonPromise<Value>, never]
 
 export function useAtom<Value, Update>(
   atom: Atom<Value> | WritableAtom<Value, Update>
@@ -25,9 +25,15 @@ export function useAtom<Value, Update>(
     useCallback(
       (state) => {
         const atomState = state.get(atom) as AtomState<Value> | undefined
-        if (!atomState) return atom.initialValue
-        if (atomState.promise) return atomState.promise
-        return atomState.value
+        if (atomState) {
+          return atomState.promise || atomState.value
+        }
+        if (atom.initialValue instanceof Promise) {
+          atom.initialValue.then(() => {
+            actions.init(null, atom)
+          })
+        }
+        return atom.initialValue
       },
       [atom]
     )

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -242,7 +242,7 @@ it('works with async get', async () => {
       <>
         <div>
           renderCount: {++renderCount.current}, count: {count}, delayedCount:{' '}
-          {delayedCount ?? 'N/A'}
+          {delayedCount}
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </>
@@ -257,14 +257,12 @@ it('works with async get', async () => {
     </Provider>
   )
 
-  await findByText('renderCount: 1, count: 0, delayedCount: N/A')
-
   await findByText('loading')
-  await findByText('renderCount: 2, count: 0, delayedCount: 0')
+  await findByText('renderCount: 1, count: 0, delayedCount: 0')
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
-  await findByText('renderCount: 3, count: 1, delayedCount: 1')
+  await findByText('renderCount: 2, count: 1, delayedCount: 1')
 })
 
 it('shows loading with async set', async () => {


### PR DESCRIPTION
Previously atom value can be `null` with async read atom. This should improve it.