### PR TITLE
chore: remove disable selection in demo

### DIFF
--- a/examples/src/style.css
+++ b/examples/src/style.css
@@ -11,7 +11,6 @@ html {
 
 * {
   box-sizing: border-box;
-  user-select: none;
 }
 
 ::selection {


### PR DESCRIPTION
The page selection is disabled for all elements, so the user does not select the code.

!['user managing to select the code'](https://i.imgur.com/9zVPsKs.png)

Is there any reason for that?