### PR TITLE
utils bundle and use update atom

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,7 @@
       },
       "alias": {
         "extensions": [".js", ".jsx", ".ts", ".tsx", ".json"],
-        "map": [["react-three-flex", "./src/index.ts"]]
+        "map": [["jotai", "./src/index.ts"]]
       }
     }
   },

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,27 +24,41 @@
     "gzipped": 1922
   },
   "index.js": {
-    "bundled": 12422,
-    "minified": 5068,
-    "gzipped": 1918,
+    "bundled": 12473,
+    "minified": 5082,
+    "gzipped": 1926,
     "treeshaked": {
       "rollup": {
-        "code": 300,
-        "import_statements": 67
+        "code": 314,
+        "import_statements": 81
       },
       "webpack": {
-        "code": 1384
+        "code": 1431
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 13819,
-    "minified": 5773,
-    "gzipped": 2016
+    "bundled": 13872,
+    "minified": 5790,
+    "gzipped": 2025
   },
   "index.iife.js": {
-    "bundled": 14634,
-    "minified": 4835,
-    "gzipped": 1819
+    "bundled": 14669,
+    "minified": 4839,
+    "gzipped": 1830
+  },
+  "utils.js": {
+    "bundled": 519,
+    "minified": 389,
+    "gzipped": 249,
+    "treeshaked": {
+      "rollup": {
+        "code": 129,
+        "import_statements": 28
+      },
+      "webpack": {
+        "code": 1183
+      }
+    }
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,23 +24,23 @@
     "gzipped": 1922
   },
   "index.js": {
-    "bundled": 12473,
-    "minified": 5082,
-    "gzipped": 1926,
+    "bundled": 12457,
+    "minified": 5068,
+    "gzipped": 1921,
     "treeshaked": {
       "rollup": {
-        "code": 314,
-        "import_statements": 81
+        "code": 300,
+        "import_statements": 67
       },
       "webpack": {
-        "code": 1431
+        "code": 1384
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 13872,
-    "minified": 5790,
-    "gzipped": 2025
+    "bundled": 13854,
+    "minified": 5773,
+    "gzipped": 2017
   },
   "index.iife.js": {
     "bundled": 14669,
@@ -48,16 +48,16 @@
     "gzipped": 1830
   },
   "utils.js": {
-    "bundled": 519,
-    "minified": 389,
-    "gzipped": 249,
+    "bundled": 277,
+    "minified": 179,
+    "gzipped": 147,
     "treeshaked": {
       "rollup": {
-        "code": 129,
+        "code": 28,
         "import_statements": 28
       },
       "webpack": {
-        "code": 1183
+        "code": 1045
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "👻 Next gen state management that will spook you",
   "main": "index.cjs.js",
   "module": "index.js",
-  "types": "src/index.d.ts",
+  "types": "index.d.ts",
   "files": [
     "**"
   ],
@@ -18,11 +18,11 @@
     "eslint-examples": "eslint --fix 'examples/src/**/*.{js,ts,jsx,tsx}'",
     "eslint:ci": "eslint '{src,examples/src}/**/*.{js,ts,jsx,tsx}'",
     "prepare": "yarn build",
-    "pretest": "tsc tests/*.test.tsx --noEmit --strict --jsx preserve -m None -t ESNext --isolatedModules --esModuleInterop --skipLibCheck --moduleResolution node",
+    "pretest": "tsc --noEmit",
     "test": "jest",
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
-    "copy": "copyfiles -f package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
+    "copy": "mv dist/src/* dist && rm -rf dist/{src,tests} && copyfiles -f package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "husky": {
     "hooks": {
@@ -62,11 +62,11 @@
   },
   "homepage": "https://github.com/react-spring/jotai",
   "jest": {
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "jest",
-      "legacy"
-    ],
+    "rootDir": ".",
+    "moduleNameMapper": {
+      "^jotai$": "<rootDir>/src/index.ts"
+    },
+    "modulePathIgnorePatterns": ["dist"],
     "testRegex": "test.(js|ts|tsx)$",
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
@@ -92,6 +92,7 @@
     "@testing-library/react": "^11.0.2",
     "@types/jest": "^26.0.13",
     "@types/react": "^16.9.49",
+    "@types/react-dom": "^16.9.8",
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",
     "copyfiles": "^2.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,10 +7,10 @@ import typescript from 'rollup-plugin-typescript2'
 const createBabelConfig = require('./babel.config')
 
 const { root } = path.parse(process.cwd())
-const external = id => !id.startsWith('.') && !id.startsWith(root)
+const external = (id) => !id.startsWith('.') && !id.startsWith(root)
 const extensions = ['.js', '.ts', '.tsx']
-const getBabelOptions = targets => ({
-  ...createBabelConfig({ env: env => env === 'build' }, targets),
+const getBabelOptions = (targets) => ({
+  ...createBabelConfig({ env: (env) => env === 'build' }, targets),
   extensions,
 })
 
@@ -68,4 +68,5 @@ export default [
   createESMConfig('src/index.ts', 'dist/index.js'),
   createCommonJSConfig('src/index.ts', 'dist/index.cjs.js'),
   createIIFEConfig('src/index.ts', 'dist/index.iife.js', 'jotai'),
+  createESMConfig('src/utils.ts', 'dist/utils.js'),
 ]

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -18,7 +18,26 @@ import {
   Getter,
   Setter,
 } from './types'
-import { appendMap, concatMap } from './utils'
+
+// mutate map with additonal map
+const appendMap = <K, V>(dst: Map<K, V>, src: Map<K, V>) => {
+  src.forEach((v, k) => {
+    dst.set(k, v)
+  })
+  return dst
+}
+
+// create new map from two maps
+const concatMap = <K, V>(src1: Map<K, V>, src2: Map<K, V>) => {
+  const dst = new Map<K, V>()
+  src1.forEach((v, k) => {
+    dst.set(k, v)
+  })
+  src2.forEach((v, k) => {
+    dst.set(k, v)
+  })
+  return dst
+}
 
 const warningObject = new Proxy(
   {},

--- a/src/useAtom.ts
+++ b/src/useAtom.ts
@@ -1,9 +1,20 @@
-import { useCallback, useRef, useDebugValue } from 'react'
+import {
+  useCallback,
+  useRef,
+  useLayoutEffect,
+  useEffect,
+  useDebugValue,
+} from 'react'
 import { useContext, useContextSelector } from 'use-context-selector'
 
 import { StateContext, ActionsContext, AtomState } from './Provider'
 import { Atom, WritableAtom, AnyWritableAtom, NonPromise } from './types'
-import { useIsoLayoutEffect } from './utils'
+
+const isClient =
+  typeof window !== 'undefined' &&
+  !/ServerSideRendering/.test(window.navigator && window.navigator.userAgent)
+
+const useIsoLayoutEffect = isClient ? useLayoutEffect : useEffect
 
 const isWritable = <Value, Update>(
   atom: Atom<Value> | WritableAtom<Value, Update>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,5 @@
-import { useLayoutEffect, useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { atom, WritableAtom, useAtom } from 'jotai'
-
-const isClient =
-  typeof window !== 'undefined' &&
-  !/ServerSideRendering/.test(window.navigator && window.navigator.userAgent)
-
-export const useIsoLayoutEffect = isClient ? useLayoutEffect : useEffect
 
 export const useUpdateAtom = <Value, Update>(
   anAtom: WritableAtom<Value, Update>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { useLayoutEffect, useEffect } from 'react'
+import { useLayoutEffect, useEffect, useMemo } from 'react'
+import { atom, WritableAtom, useAtom } from 'jotai'
 
 const isClient =
   typeof window !== 'undefined' &&
@@ -6,20 +7,12 @@ const isClient =
 
 export const useIsoLayoutEffect = isClient ? useLayoutEffect : useEffect
 
-export const appendMap = <K, V>(dst: Map<K, V>, src: Map<K, V>) => {
-  src.forEach((v, k) => {
-    dst.set(k, v)
-  })
-  return dst
-}
-
-export const concatMap = <K, V>(src1: Map<K, V>, src2: Map<K, V>) => {
-  const dst = new Map<K, V>()
-  src1.forEach((v, k) => {
-    dst.set(k, v)
-  })
-  src2.forEach((v, k) => {
-    dst.set(k, v)
-  })
-  return dst
+export const useUpdateAtom = <Value, Update>(
+  anAtom: WritableAtom<Value, Update>
+) => {
+  const writeOnlyAtom = useMemo(
+    () => atom(null, (_get, set, update: Update) => set(anAtom, update)),
+    [anAtom]
+  )
+  return useAtom(writeOnlyAtom)[1]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "jsx": "preserve",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "jotai": ["./src/index.ts"]
+    }
   },
   "include": [
     "src/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,7 +1308,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react@^16.9.49":
+"@types/react-dom@^16.9.8":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.9.49":
   version "16.9.49"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
   integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==


### PR DESCRIPTION
ref: #26 

This adds new `utils` bundle, that is separated from core.

```js
import { atom, useAtom } from 'jotai'
import { useUpdateAtom } from 'jotai/utils'

const countAtom = atom(0)

const Counter = () => {
  const [count] = useAtom(countAtom)
  return <div>count: {count}</div>
}

const Controls = () => {
  const setCount = useUpdateAtom(countAtom)
  const inc = () => setCount(c => c + 1)
  return <button onClick={inc}>+1</button>
}
```