### PR TITLE
reducer related utils

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -48,9 +48,9 @@
     "gzipped": 1866
   },
   "utils.js": {
-    "bundled": 277,
-    "minified": 179,
-    "gzipped": 147,
+    "bundled": 735,
+    "minified": 389,
+    "gzipped": 234,
     "treeshaked": {
       "rollup": {
         "code": 28,

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -65,22 +65,48 @@ const TodoList = () => {
 
 https://codesandbox.io/s/react-typescript-forked-w91cq
 
-## reducerAtom
+## useReducerAtom
+
+```js
+import { atom } from 'jotai'
+import { useReducerAtom } from 'jotai/utils'
+
+const countReducer = (prev, action) => {
+  if (action.type === 'inc') return prev + 1
+  if (action.type === 'dec') return prev - 1
+  throw new Error('unknown action type')
+}
+
+const countAtom = atom(0)
+
+const Counter = () => {
+  const [count, dispatch] = useReducerAtom(countAtom, countReducer);
+  return (
+    <div>
+      {count}
+      <button onClick={() => dispatch({ type: "inc" })}>+1</button>
+      <button onClick={() => dispatch({ type: "dec" })}>-1</button>
+    </div>
+  );
+};
+```
+
+https://codesandbox.io/s/react-typescript-forked-eg0mw
+
+## atomWithReducer
 
 Ref: https://github.com/react-spring/jotai/issues/38
 
 ```js
-import { reducerAtom } from 'jotai/utils'
+import { atomWithReducer } from 'jotai/utils'
 
 const countReducer = (prev, action) => {
-  if (action.type === 'inc') {
-    return prev + 1
-  } else if (action.type === 'dec') {
-    return prev - 1
-  } else {
-    throw new Error('unknown action type')
-  }
+  if (action.type === 'inc') return prev + 1
+  if (action.type === 'dec') return prev - 1
+  throw new Error('unknown action type')
 }
 
-const countReducerAtom = reducerAtom(0, countReducer)
+const countReducerAtom = atomWithReducer(0, countReducer)
 ```
+
+https://codesandbox.io/s/react-typescript-forked-g3tsx

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -23,3 +23,23 @@ const Controls = () => {
 ```
 
 https://codesandbox.io/s/react-typescript-forked-3q11k
+
+## reducerAtom
+
+Ref: https://github.com/react-spring/jotai/issues/38
+
+```js
+import { reducerAtom } from 'jotai/utils'
+
+const countReducer = (prev, action) => {
+  if (action.type === 'inc') {
+    return prev + 1
+  } else if (action.type === 'dec') {
+    return prev - 1
+  } else {
+    throw new Error('unknown action type')
+  }
+}
+
+const countReducerAtom = reducerAtom(0, countReducer)
+```

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,9 @@
 import { useMemo } from 'react'
 import { atom, WritableAtom, useAtom } from 'jotai'
 
+type NonPromise<T> = T extends Promise<unknown> ? never : T
+type NonFunction<T> = T extends Function ? never : T
+
 export const useUpdateAtom = <Value, Update>(
   anAtom: WritableAtom<Value, Update>
 ) => {
@@ -9,4 +12,14 @@ export const useUpdateAtom = <Value, Update>(
     [anAtom]
   )
   return useAtom(writeOnlyAtom)[1]
+}
+
+export const reducerAtom = <Value, Action>(
+  initialValue: NonFunction<NonPromise<Value>>,
+  reducer: (v: Value, a: Action) => Value
+) => {
+  const anAtom: any = atom<Value, Action>(initialValue, (get, set, action) =>
+    set(anAtom, reducer(get(anAtom), action))
+  )
+  return anAtom as WritableAtom<Value, Action>
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,7 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { atom, WritableAtom, useAtom } from 'jotai'
 
-type NonPromise<T> = T extends Promise<unknown> ? never : T
-type NonFunction<T> = T extends Function ? never : T
+import type { NonPromise, NonFunction, PrimitiveAtom } from './types'
 
 export const useUpdateAtom = <Value, Update>(
   anAtom: WritableAtom<Value, Update>
@@ -14,7 +13,21 @@ export const useUpdateAtom = <Value, Update>(
   return useAtom(writeOnlyAtom)[1]
 }
 
-export const reducerAtom = <Value, Action>(
+export const useReducerAtom = <Value, Action>(
+  anAtom: PrimitiveAtom<Value>,
+  reducer: (v: Value, a: Action) => NonFunction<Value>
+) => {
+  const [state, setState] = useAtom(anAtom)
+  const dispatch = useCallback(
+    (action: Action) => {
+      setState((prev) => reducer(prev, action))
+    },
+    [setState, reducer]
+  )
+  return [state, dispatch] as const
+}
+
+export const atomWithReducer = <Value, Action>(
   initialValue: NonFunction<NonPromise<Value>>,
   reducer: (v: Value, a: Action) => Value
 ) => {


### PR DESCRIPTION
Close #38 

- [x] snippets
- [x] codesandbox examples
- [x] docs/utils.md

```js
import { atomWithReducer } from 'jotai/utils'

const countReducer = (prev, action) => {
  if (action.type === 'inc') {
    return prev + 1
  } else if (action.type === 'dec') {
    return prev - 1
  } else {
    throw new Error('unknown action type')
  }
}

const countReducerAtom = atomWithReducer(0, countReducer)
```

https://codesandbox.io/s/react-typescript-forked-g3tsx

```js
import { atom } from 'jotai'
import { useReducerAtom } from 'jotai/utils'

const countAtom = atom(0)

  const [count, dispatch] = useReducerAtom(countAtom, countReducer)
```

https://codesandbox.io/s/react-typescript-forked-eg0mw